### PR TITLE
add alb zone_id and alb arn to output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -24,3 +24,13 @@ output "concourse_password" {
 output "alb_name" {
   value = "${aws_lb.concourse.name}"
 }
+output "alb_zone_id" {
+  description = "concourse LB's zone-id. used for route53"
+  value = "${aws_lb.concourse.zone_id}"
+}
+
+output "alb_arn" {
+  description = "concourse LB ARN"
+  value = "${aws_lb.concourse.arn}"
+}
+


### PR DESCRIPTION
heya, great module!

this pr just creates two outputs - 

one exposes the concourse alb's zone_id - so we can use resource.route53
the other exposes the alb's ARN in case one might set up a specific ssl termination policy or something to that effect.